### PR TITLE
fix: Bump @types/jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,19 +1791,13 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.18",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
-      "integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
+      "version": "24.0.25",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.25.tgz",
+      "integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
       "dev": true,
       "requires": {
-        "@types/jest-diff": "*"
+        "jest-diff": "^24.3.0"
       }
-    },
-    "@types/jest-diff": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
-      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
-      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@storybook/addon-notes": "5.2.0",
     "@storybook/addon-viewport": "5.2.0",
     "@storybook/html": "5.2.0",
-    "@types/jest": "24.0.18",
+    "@types/jest": "24.0.25",
     "@types/stripe-v3": "^3.1.7",
     "babel-loader": "^8.0.6",
     "copy-webpack-plugin": "^5.0.4",


### PR DESCRIPTION
Hi,

the first time build currently fails due to a TypeScript error caused by `@types/jest` package.
Upgrading the package to a newer version (`24.0.25`) fixes the TypeScript error and the installation completes successfully again.

Fixes #5

--
Related issue on DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39243